### PR TITLE
Colors on Hostname

### DIFF
--- a/bashrc
+++ b/bashrc
@@ -171,7 +171,8 @@ COLOR_L_PURPLE='\[\e[1;35m\]'
 COLOR_L_CYAN='\[\e[1;36m\]'
 COLOR_L_WHITE='\[\e[1;37m\]'
 
-# Color set for hostname highlighting
+# color set for hostname highlighting
+# it's better to choose colors that looks different
 HOST_COLORS=("$COLOR_L_CYAN"   \
              "$COLOR_L_RED"    \
              "$COLOR_L_GREEN"  \
@@ -188,11 +189,15 @@ while test -n "$STR_HOST"; do
    STR_HOST=${STR_HOST:1}
 done
 
+# pick a color from set by checksum
+SELECTIONS=${#HOST_COLORS[@]}
+HOST_COLOR=${HOST_COLORS[$(($CHECKSUM % $SELECTIONS))]}
+
 # my bash prompt
 PS1='┌─'$COLOR_L_BLUE'[ \d-\t ]'$COLOR_END           # date
 PS1+=$COLOR_YELLOW' \u '$COLOR_END                     # user
 PS1+=$COLOR_L_BLACK'@'$COLOR_END                       # @
-PS1+=$COLOR_L_GREEN' \h '$COLOR_END                    # host
+PS1+=$HOST_COLOR' \h '$COLOR_END                    # host
 PS1+='$(ret_code)'                                     # return code
 PS1+=$COLOR_L_PURPLE'$(__git_ps1 "[ ~> on %s ]")'$COLOR_END
                                                        # git info


### PR DESCRIPTION
This patch add colors to hostname on command prompt automatically.

Checksum generate based on hostname characters, then pick up a color set in $HOST_COLORS. This prevent shutting down the wrong server for me. 
